### PR TITLE
fix: 修复文章页面末尾在拼接 URL 时产生多余的斜杠

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -120,7 +120,10 @@
           <div th:text="${post.spec.title}"></div>
           <div
             class="license-item mt-1"
-            th:text="${site.url} + ${post.status.permalink}"
+            th:with="cleanedUrl=${#strings.endsWith(site.url, '/')
+              ? #strings.substring(site.url, 0, #strings.length(site.url)-1)
+              : site.url}"
+            th:text="${cleanedUrl + post.status.permalink}"
           ></div>
 
           <div class="mt-3 gap-12 sm:flex">


### PR DESCRIPTION
问题：当外部访问地址携带“/”时会出现如下情况，造成url拼接错误，无法正常访问。
---
![image](https://github.com/user-attachments/assets/12932247-d18a-4984-9978-17c5eeaf10dc)

